### PR TITLE
Update js-parser.yml

### DIFF
--- a/.github/workflows/js-parser.yml
+++ b/.github/workflows/js-parser.yml
@@ -1,16 +1,10 @@
 name: js-parser
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 jobs:
   test:
-    name: Test js-parser.
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -35,28 +29,4 @@ jobs:
         run: |
           npm ci
           npm test
-        env:
-          CI: true
-
-  publish-gpr:
-    name: Publish js-parser.
-    needs: test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      # Setup .npmrc file to publish to GitHub Packages.
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-          registry-url: https://npm.pkg.github.com/
-          scope: "@m-voit"
-
-      - name: Publish js parser.
-        working-directory: ./js-parser
-        run: |
-          npm ci
-          npm publish
-        env:
-          CI: true
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  


### PR DESCRIPTION
Remove js parser publish job from js parser action. Testing on push and pull requests is now done separately from publishing a new js parser package.